### PR TITLE
Fixes incorrect description of some matchers

### DIFF
--- a/Mimus.xcodeproj/project.pbxproj
+++ b/Mimus.xcodeproj/project.pbxproj
@@ -351,18 +351,19 @@
 				TargetAttributes = {
 					10115C271E6DA39B0001E9A2 = {
 						CreatedOnToolsVersion = 8.2;
+						DevelopmentTeam = 287LWMYEQ7;
 						LastSwiftMigration = 0910;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 					10115C301E6DA39B0001E9A2 = {
 						CreatedOnToolsVersion = 8.2;
-						DevelopmentTeam = PDY79HZ4XW;
+						DevelopmentTeam = 287LWMYEQ7;
 						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 					10539B571E7BF218006EA51F = {
 						CreatedOnToolsVersion = 8.2;
-						DevelopmentTeam = PDY79HZ4XW;
+						DevelopmentTeam = 287LWMYEQ7;
 						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
@@ -604,9 +605,11 @@
 		10115C3D1E6DA39B0001E9A2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 287LWMYEQ7;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -621,10 +624,12 @@
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.Mimus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -632,9 +637,11 @@
 		10115C3E1E6DA39B0001E9A2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 287LWMYEQ7;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -649,10 +656,12 @@
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.Mimus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -660,44 +669,64 @@
 		10115C401E6DA39B0001E9A2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = PDY79HZ4XW;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 287LWMYEQ7;
 				INFOPLIST_FILE = Tests/MimusTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 			};
 			name = Debug;
 		};
 		10115C411E6DA39B0001E9A2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = PDY79HZ4XW;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 287LWMYEQ7;
 				INFOPLIST_FILE = Tests/MimusTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 			};
 			name = Release;
 		};
 		10539B611E7BF218006EA51F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = PDY79HZ4XW;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 287LWMYEQ7;
 				INFOPLIST_FILE = Tests/MimusExamples/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 			};
 			name = Debug;
 		};
 		10539B621E7BF218006EA51F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = PDY79HZ4XW;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 287LWMYEQ7;
 				INFOPLIST_FILE = Tests/MimusExamples/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 			};
 			name = Release;
 		};

--- a/Sources/Mimus/Matchers/EqualMatcher.swift
+++ b/Sources/Mimus/Matchers/EqualMatcher.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class EqualTo<T: Equatable>: Matcher {
+public final class EqualTo<T: Equatable>: Matcher, CustomStringConvertible {
 
     private let object: T?
 

--- a/Sources/Mimus/Matchers/IdenticalMatcher.swift
+++ b/Sources/Mimus/Matchers/IdenticalMatcher.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class IdenticalTo<T: AnyObject>: Matcher {
+public final class IdenticalTo<T: AnyObject>: Matcher, CustomStringConvertible {
 
     private let object: T?
 

--- a/Sources/Mimus/Matchers/NotMatcher.swift
+++ b/Sources/Mimus/Matchers/NotMatcher.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public class NotMatcher: Matcher {
+public class NotMatcher: Matcher, CustomStringConvertible {
     private let containedMatcher: Matcher
 
     public init(containedMatcher: Matcher) {
@@ -16,6 +16,6 @@ public class NotMatcher: Matcher {
     }
 
     public var description: String {
-        return "\(type(of: self)) - \(containedMatcher)"
+        return "\(type(of: self)) - \(String(describing: containedMatcher))"
     }
 }

--- a/Sources/Mimus/Mock.swift
+++ b/Sources/Mimus/Mock.swift
@@ -81,6 +81,10 @@ public extension Mock {
         let callCandidates = storage.recordedCalls.filter {
             $0.identifier == callIdentifier
         }
+        
+        // Note we explicitly reset storage _before_ triggering verification as verification might add new values to
+        // the storage which we want to keep around for additional verification (e.g. when simulating callbacks).
+        storage.reset()
 
         let matchResults = callCandidates.map({ mockMatcher.match(expected: arguments, actual: $0.arguments) })
 
@@ -94,8 +98,6 @@ public extension Mock {
             testLocation: testLocation)
 
         TestLocation.internalTestLocation = nil
-
-        storage.reset()
     }
 
     func record(returnValue: Any?, forCallWithIdentifier identifier: String, arguments: [Any?]? = nil) {

--- a/Tests/MimusTests/MismatchMessageBuilderTests.swift
+++ b/Tests/MimusTests/MismatchMessageBuilderTests.swift
@@ -39,6 +39,30 @@ class MismatchMessageBuilderTests: XCTestCase {
         let expectedMessage = "Mismatch in argument #1 - expected <(1)>, but was <(2)>."
         XCTAssertEqual(message, expectedMessage, "Expected to receive correct mismatch details")
     }
+    
+    func testOneComparisonWithExpectedValueAsEqualMatcherAndActualValues() {
+        let comparison = MimusComparator.ComparisonResult.MismatchedComparison(
+            argumentIndex: 1,
+            expected: mEqual(Int(1)),
+            actual: 2
+        )
+        let result = MimusComparator.ComparisonResult(matching: false, mismatchedComparisons: [comparison])
+        let message = mismatchMessageBuilder.message(for: [result])
+        let expectedMessage = "Mismatch in argument #1 - expected <(EqualTo<Int> - <(1)>)>, but was <(2)>."
+        XCTAssertEqual(message, expectedMessage, "Expected to receive correct mismatch details")
+    }
+    
+    func testOneComparisonWithExpectedValueAsNotEqualMatcherAndActualValues() {
+        let comparison = MimusComparator.ComparisonResult.MismatchedComparison(
+            argumentIndex: 1,
+            expected: mNot(mEqual(Int(1))),
+            actual: 1
+        )
+        let result = MimusComparator.ComparisonResult(matching: false, mismatchedComparisons: [comparison])
+        let message = mismatchMessageBuilder.message(for: [result])
+        let expectedMessage = "Mismatch in argument #1 - expected <(NotMatcher - EqualTo<Int> - <(1)>)>, but was <(1)>."
+        XCTAssertEqual(message, expectedMessage, "Expected to receive correct mismatch details")
+    }
 
     func testOneComparisonWithExpectedNil() {
         let comparison = MimusComparator.ComparisonResult.MismatchedComparison(argumentIndex: 1, expected: nil, actual: 2)

--- a/Tests/MimusTests/MockTests.swift
+++ b/Tests/MimusTests/MockTests.swift
@@ -121,6 +121,21 @@ class MockTests: XCTestCase {
         XCTAssertEqual(fakeVerificationHandler.lastMismatchedArgumentsResults?.count, 0, "Expected no mismatched result")
     }
 
+    func testCorrectNumberOfMatchesAfterVeryfingTwoTimesWithNewRecordingDuringVerification() {
+        let matcher = ClosureMatcher<Int>({ _ in
+            self.mockRecorder.recordCall(withIdentifier: "Fixture Identifier 2")
+            return true
+        })
+        
+        mockRecorder.recordCall(withIdentifier: "Fixture Identifier", arguments: [Int(42)])
+        mockRecorder.verifyCall(withIdentifier: "Fixture Identifier", arguments: [matcher])
+        
+        mockRecorder.verifyCall(withIdentifier: "Fixture Identifier 2")
+
+        XCTAssertEqual(fakeVerificationHandler.lastMatchedResults?.count, 1, "Expected one matched result")
+        XCTAssertEqual(fakeVerificationHandler.lastMismatchedArgumentsResults?.count, 0, "Expected no mismatched result")
+    }
+    
     func testCaptureArgument() {
         let argumentCaptor = CaptureArgumentMatcher()
 


### PR DESCRIPTION
The current logic resulted in matchers lacking specific content description (they were printed as just `EqualTo<Int>').

This also fixes case where reset storage was called _after_ verification which resulted in calls that were recorded during verification (e.g. via closure matcher) being removed when they should not be removed.

This also fixes (again) code sign on Macs & updates the lib to better support Xcode 12.5.